### PR TITLE
A few minor improvements

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -68,7 +68,9 @@ function toolranks.new_afteruse(itemstack, user, node, digparams)
   if lastlevel < level then
     local levelup_text = "Your " .. toolranks.colors.green ..
                          itemdesc .. toolranks.colors.white ..
-                         " just leveled up!"
+                         " just leveled up to " ..
+                         toolranks.colors.green .. "level " ..
+                         level .. toolranks.colors.white .. "!"
     minetest.sound_play("toolranks_levelup", {
       to_player = user:get_player_name(),
       gain = 2.0,

--- a/init.lua
+++ b/init.lua
@@ -32,20 +32,16 @@ function toolranks.create_description(name, uses, level)
   return newdesc
 end
 
+function toolranks.log2(value)
+  return math.log(value) / math.log(2)
+end
+
 function toolranks.get_level(uses)
-  if uses <= 100 then
-    return 1
-  elseif uses < 200 then
-    return 2
-  elseif uses < 400 then
-    return 3
-  elseif uses < 800 then
-    return 4
-  elseif uses < 1600 then
-    return 5
-  else
-    return 6
+  level = math.ceil(toolranks.log2(uses / 100)) + 1
+  if level < 1 then
+    level = 1
   end
+  return level
 end
 
 function toolranks.new_afteruse(itemstack, user, node, digparams)


### PR DESCRIPTION
This patch allows an infinite number of levels. It mimics the behavior as it was before by calculating the new level with a log2 function of the number of uses divided by 100.
In addition, I modified the chat message to print out the new level of the tool as well, in a separate commit.