### PR TITLE
Add register_extra_tool_type function

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,9 @@ and then replace all after_use definitions with toolranks.new_afteruse.
 Optionaly, you can also replace tools description with
 ```toolranks.create_description("Tool Name", 0, 1)```
 and then set original_description to your tools name.
+
+You can add custom tool types using
+```toolranks.register_extra_tool_type(keyword, tool_type)``` with `keyword`
+being string to be detected in tool description and `tool_type`, a localized tool type.
+Example:
+```toolranks.register_extra_tool_type("bow", S("bow"))```.

--- a/init.lua
+++ b/init.lua
@@ -10,23 +10,45 @@ toolranks.colors = {
   white = minetest.get_color_escape_sequence("#ffffff")
 }
 
+toolranks.extra_tool_types = {}
+
+function toolranks.register_extra_tool_type(keyword, tool_type)
+  toolranks.extra_tool_types[keyword] = tool_type
+end
+
+local function get_extra_tool_type(description)
+  local d = string.lower(description)
+  for k, desc in pairs(toolranks.extra_tool_types) do
+    if string.find(d, string.lower(k)) then
+      return desc
+    end
+  end
+  return nil
+end
+
+
 function toolranks.get_tool_type(description)
   if not description then
-    return "tool"
+    return S("tool")
   else
-    local d = string.lower(description)
-    if string.find(d, "pickaxe") then
-      return "pickaxe"
-    elseif string.find(d, "axe") then
-      return "axe"
-    elseif string.find(d, "shovel") then
-      return "shovel"
-    elseif string.find(d, "hoe") then
-      return "hoe"
-    elseif string.find(d, "sword") then
-      return "sword"
+    local tool_type = get_extra_tool_type(description)
+    if tool_type then
+      return tool_type
     else
-      return "tool"
+      local d = string.lower(description)
+      if string.find(d, "pickaxe") then
+        return S("pickaxe")
+      elseif string.find(d, "axe") then
+        return S("axe")
+      elseif string.find(d, "shovel") then
+        return S("shovel")
+      elseif string.find(d, "hoe") then
+        return S("hoe")
+      elseif string.find(d, "sword") then
+        return S("sword")
+      else
+        return S("tool")
+      end
     end
   end
 end
@@ -40,7 +62,7 @@ function toolranks.create_description(name, uses, level)
                     description,
                     toolranks.colors.gold,
                     (level or 1),
-                    S(tooltype),
+                    tooltype,
                     toolranks.colors.grey,
                     (uses or 0))
   return newdesc


### PR DESCRIPTION
This will allow external mods to register new tool types.
As an example, a mod creating bows can use toolranks without bows beeing
hardcoded in toolranks mod.